### PR TITLE
Consolidate design with code

### DIFF
--- a/domaindesign.md
+++ b/domaindesign.md
@@ -119,19 +119,19 @@ Slide "1" <-- "1" Content: content
 ```mermaid
 classDiagram
 class Content{
-	<<abstract>>
+	<<Interface>>
 	+getComposite(): CompositeContent|null
 }
 class CompositeContent{
-	-elements : Vector of Content
+    <<Interface>>
     +getIterator():Iterator of Content
 }
 class List{
     -bulleted: boolean
+    +getIterator():Iterator of Content
 }
 class Table{
-    -rowCount: int
-    -columnCount: int
+    +getIterator():Iterator of Content
 }
 class Figure{
     -source: URL


### PR DESCRIPTION
Remove rowCount and columnCount from Table in design document. Moved getIterator to classes, because that is not implemented in CompositeContent, and added interface annotations.

I want to use the correct class diagrams in the report, so maybe there will be some more changes like this coming in the next few days.