### PR TITLE
Consolidate design with code

### DIFF
--- a/domain-services-design.md
+++ b/domain-services-design.md
@@ -82,3 +82,25 @@ classDiagram
     SlideFactory <|-- SimpleSlideFactory
     ContentFactory <|-- SimpleContentFactory
 ~~~
+
+## GUI
+### GUIFacade
+| Type | Responsibility                                                            | Comments | Remarks |
+|------|---------------------------------------------------------------------------|----------|---------|
+| Know | SlideShow                                                                 |          |         |
+| Can  | Present the slides from a slide show                                      |          |         |
+|      | Call the stop action from a stop strategy implementation                  |          |         |
+
+~~~mermaid
+classDiagram
+    class GUIFacade {
+        <<interface>>
+        +showSlideShow()
+    }
+
+    class SwingGUIFacade {
+        +showSlideShow()
+    }
+
+    GUIFacade <|-- SwingGUIFacade
+~~~

--- a/domaindesign.md
+++ b/domaindesign.md
@@ -105,6 +105,7 @@ Slide "1" <-- "1" Content: content
 - Design pattern **Composite** for content and its subtypes.
 - **Iterator** to navigate through these
 - It is a possibility to include Slide and even SlideShow into the Composite hierarchy. We decided against that, because we see too much difference between Slide/SlideShow and the other Components and too little shared functionality.
+- **Visitor** to implement features that need to act upon the specific subclasses of Content, where we do not want to add the funcionality to the Content classes themselves. For example showing content in a GUI.
 
 ### Mapping for Composite
 
@@ -195,6 +196,31 @@ class SlideIterator {
     Iterator <|-- ContentIterator
     ContentIterator <|-- ListIterator
     ContentIterator <|-- TableIterator
+```
+
+```mermaid
+classDiagram
+    class ContentVisitor {
+        <<Interface>>
+        +doForListStart(ListContent)
+        +doForListEnd(ListContent)
+        +doForTableStart(TableContent)
+        +doForTableEnd(TableContent)
+        +doForTableRowStart(TableContent)
+        +doForTableRowEnd(TableContent)
+        +doForText(Text)
+        +doForFigure(Figure)
+    }
+
+    class ContentRenderer {
+        
+    }
+
+    class Content {
+        +accept(ContentVisitor)
+    }
+
+    ContentVisitor <|-- ContentRenderer
 ```
 
 ## Rules

--- a/domaindesign.md
+++ b/domaindesign.md
@@ -119,19 +119,19 @@ Slide "1" <-- "1" Content: content
 ```mermaid
 classDiagram
 class Content{
-	<<abstract>>
+	<<Interface>>
 	+getComposite(): CompositeContent|null
 }
 class CompositeContent{
-	-elements : Vector of Content
+    <<Interface>>
     +getIterator():Iterator of Content
 }
 class List{
     -bulleted: boolean
+    +getIterator():Iterator of Content
 }
 class Table{
-    -rowCount: int
-    -columnCount: int
+    +getIterator():Iterator of Content
 }
 class Figure{
     -source: URL


### PR DESCRIPTION
I want to use the correct class diagrams in the report, so maybe there will be some more changes like this coming in the next few days.

Remove rowCount and columnCount from Table in design document. Moved getIterator to classes, because that is not implemented in CompositeContent, and added interface annotations.

Added Visitor pattern to the domain design documentation.